### PR TITLE
Exclude deprecated YoutubeAudioSourceManager via registerRemoteSources()

### DIFF
--- a/src/main/kotlin/dev/arbjerg/ukulele/audio/LavaplayerConfig.kt
+++ b/src/main/kotlin/dev/arbjerg/ukulele/audio/LavaplayerConfig.kt
@@ -25,17 +25,9 @@ class LavaplayerConfig {
         // Add the new YoutubeAudioSourceManager
         apm.registerSourceManager(YoutubeAudioSourceManager(true))
 
-        // Port the rest from `com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers.registerRemoteSources`
-        // while excluding the legacy `YoutubeAudioSourceManager`
-        apm.registerSourceManager(YandexMusicAudioSourceManager(true))
-        apm.registerSourceManager(SoundCloudAudioSourceManager.createDefault())
-        apm.registerSourceManager(BandcampAudioSourceManager())
-        apm.registerSourceManager(VimeoAudioSourceManager())
-        apm.registerSourceManager(TwitchStreamAudioSourceManager())
-        apm.registerSourceManager(BeamAudioSourceManager())
-        apm.registerSourceManager(GetyarnAudioSourceManager())
-        apm.registerSourceManager(NicoAudioSourceManager())
-        apm.registerSourceManager(HttpAudioSourceManager(MediaContainerRegistry.DEFAULT_REGISTRY))
+        @Suppress("DEPRECATION") val exclusions =
+            arrayOf(com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager::class.java)
+        AudioSourceManagers.registerRemoteSources(apm, *exclusions)
 
         return apm
     }


### PR DESCRIPTION
I found this exclusion mechanism that could be used instead of porting the contents of the function.  I put it in my fork and wanted to share with you in case you would like to use it.  Thanks for everything you do... I learn from following your examples.