### PR TITLE
Prefer reading env vars before config for bot token, activity message and command prefix

### DIFF
--- a/src/main/kotlin/dev/arbjerg/ukulele/jda/CommandManager.kt
+++ b/src/main/kotlin/dev/arbjerg/ukulele/jda/CommandManager.kt
@@ -42,7 +42,7 @@ class CommandManager(
     fun onMessage(guild: Guild, channel: TextChannel, member: Member, message: Message) {
         GlobalScope.launch {
             val guildProperties = guildProperties.getAwait(guild.idLong)
-            val prefix = guildProperties.prefix ?: botProps.prefix
+            val prefix = System.getenv("PREFIX") ?: guildProperties.prefix ?: botProps.prefix
 
             val name: String
             val trigger: String

--- a/src/main/kotlin/dev/arbjerg/ukulele/jda/JdaConfig.kt
+++ b/src/main/kotlin/dev/arbjerg/ukulele/jda/JdaConfig.kt
@@ -21,8 +21,9 @@ class JdaConfig {
 
     @Bean
     fun shardManager(botProps: BotProps, eventHandler: EventHandler): ShardManager {
-        if (botProps.token.isBlank()) throw RuntimeException("Discord token not configured!")
-        val activity = if (botProps.game.isBlank()) Activity.playing("music") else Activity.playing(botProps.game)
+        val token = System.getenv("TOKEN") ?: botProps.token
+        if (token.isBlank()) throw RuntimeException("Discord token not configured!")
+        val activity = Activity.playing(System.getenv("ACTIVITY") ?: (botProps.game).ifBlank { "music" })
 
 
         val intents = listOf(
@@ -32,7 +33,7 @@ class JdaConfig {
                 DIRECT_MESSAGES
         )
 
-        val builder = DefaultShardManagerBuilder.create(botProps.token, intents)
+        val builder = DefaultShardManagerBuilder.create(token, intents)
                 .disableCache(CacheFlag.ACTIVITY, CacheFlag.EMOTE, CacheFlag.CLIENT_STATUS)
                 .setBulkDeleteSplittingEnabled(false)
                 .setEnableShutdownHook(false)


### PR DESCRIPTION
This really helps with not packaging the token in plain text in the config when trying to deploy it on cloud.

Also means you can pull the GitHub package directly from https://github.com/jocull/ukulele/pkgs/container/ukulele and set up the env vars as container configuration, so there's never any need to download the files for the bot except to contribute.